### PR TITLE
Add session/agent ID copy button to breadcrumb

### DIFF
--- a/docs/superpowers/specs/2026-03-26-session-id-copy-design.md
+++ b/docs/superpowers/specs/2026-03-26-session-id-copy-design.md
@@ -5,7 +5,7 @@
 
 ## Overview
 
-Add a clickable hash button to the conversation header breadcrumb so users can copy session IDs (and agent IDs) to the clipboard — either as a raw ID or as a ready-to-run `claude -c <id>` command.
+Add a clickable hash button to the conversation header breadcrumb so users can copy session IDs (and agent IDs) to the clipboard — either as a raw ID, a ready-to-run `claude -c <id>` resume command, or a `claude -r <id> --fork-session` fork command.
 
 ## Breadcrumb Structure
 
@@ -35,10 +35,11 @@ A single shared `<div id="hash-dropdown">` lives in the document (created once, 
 
 **Contents:**
 ```
-┌─────────────────────────┐
-│ Copy ID                 │
-│ Copy claude -c <hash>   │
-└─────────────────────────┘
+┌──────────────────────────────────────────┐
+│ Copy ID                                  │
+│ Copy claude -c <hash>                    │
+│ Copy claude -r <hash> --fork-session     │
+└──────────────────────────────────────────┘
 ```
 
 **Behavior:**
@@ -79,7 +80,7 @@ No changes to `agentManagerPanel.ts`, `claudeReader.ts`, or `types.ts`. No new e
 
 ## Acceptance Criteria
 
-- [ ] Clicking the session hash in the breadcrumb opens a dropdown with "Copy ID" and "Copy `claude -c <id>`"
+- [ ] Clicking the session hash in the breadcrumb opens a dropdown with "Copy ID", "Copy `claude -c <id>`", and "Copy `claude -r <id> --fork-session`"
 - [ ] Clicking the agent hash in an agent-view breadcrumb opens the same dropdown for the agent ID
 - [ ] Selecting an option copies the correct string to the clipboard
 - [ ] The button shows "Copied!" for ~1.5s after a successful copy

--- a/media/main.js
+++ b/media/main.js
@@ -25,6 +25,8 @@
   /** @type {string | null} */
   let currentSessionCwd = null;
   let hasLiveTerminal = false;
+  /** @type {HTMLElement | null} */
+  let _dropdownActiveBtn = null;
 
   // Forward declarations for later tasks (Task 3 will declare properly)
   let focusedIndex = -1;
@@ -228,6 +230,22 @@
   document.addEventListener('click', (e) => {
     if (!e.target.closest('.settings-wrap')) {
       settingsPanel.classList.remove('open');
+    }
+  });
+
+  document.addEventListener('click', function (e) {
+    const btn = /** @type {HTMLElement} */ (e.target).closest('.hash-btn');
+    if (btn) {
+      const dropdown = document.getElementById('hash-dropdown');
+      if (dropdown && dropdown.style.display !== 'none' && _dropdownActiveBtn === btn) {
+        closeHashDropdown();
+      } else {
+        openHashDropdown(/** @type {HTMLElement} */ (btn));
+      }
+      return;
+    }
+    if (!/** @type {HTMLElement} */ (e.target).closest('#hash-dropdown')) {
+      closeHashDropdown();
     }
   });
 
@@ -619,6 +637,57 @@
     if (layoutMode === 'narrow' && typeof renderIconRail === 'function') renderIconRail();
   }
 
+  function ensureHashDropdown() {
+    let el = document.getElementById('hash-dropdown');
+    if (el) return el;
+    el = document.createElement('div');
+    el.id = 'hash-dropdown';
+    el.style.display = 'none';
+    el.innerHTML =
+      '<div class="hash-dropdown-item" data-action="id">Copy ID</div>' +
+      '<div class="hash-dropdown-item" data-action="cmd">Copy claude -c \u2026</div>' +
+      '<div class="hash-dropdown-item" data-action="fork">Copy claude -r \u2026 --fork-session</div>';
+    document.body.appendChild(el);
+    el.addEventListener('click', function (ev) {
+      ev.stopPropagation();
+      const item = /** @type {HTMLElement} */ (ev.target).closest('.hash-dropdown-item');
+      if (!item) return;
+      const id = el.dataset.currentId || '';
+      const action = item.dataset.action;
+      const text = action === 'cmd' ? `claude -c ${id}` : action === 'fork' ? `claude -r ${id} --fork-session` : id;
+      const activeBtn = _dropdownActiveBtn;
+      closeHashDropdown();
+      navigator.clipboard.writeText(text).then(() => {
+        if (!activeBtn) return;
+        const orig = activeBtn.textContent;
+        activeBtn.textContent = 'Copied!';
+        setTimeout(() => { activeBtn.textContent = orig; }, 1500);
+      });
+    });
+    return el;
+  }
+
+  function openHashDropdown(btn) {
+    const dropdown = ensureHashDropdown();
+    _dropdownActiveBtn = btn;
+    dropdown.dataset.currentId = btn.dataset.id || '';
+    const short = (btn.dataset.id || '').slice(0, 8);
+    const cmdItem = dropdown.querySelector('[data-action="cmd"]');
+    if (cmdItem) cmdItem.textContent = `Copy claude -c ${short}\u2026`;
+    const forkItem = dropdown.querySelector('[data-action="fork"]');
+    if (forkItem) forkItem.textContent = `Copy claude -r ${short}\u2026 --fork-session`;
+    const rect = btn.getBoundingClientRect();
+    dropdown.style.top = `${rect.bottom + 4}px`;
+    dropdown.style.left = `${rect.left}px`;
+    dropdown.style.display = 'block';
+  }
+
+  function closeHashDropdown() {
+    const el = document.getElementById('hash-dropdown');
+    if (el) el.style.display = 'none';
+    _dropdownActiveBtn = null;
+  }
+
   function selectConversation(projectKey, sessionId, agentId, rowEl) {
     selectedSessionId = sessionId;
     selectedAgentId = agentId;
@@ -658,10 +727,13 @@
     const breadcrumb = document.getElementById('conv-breadcrumb');
     const project = allProjects.find((p) => p.key === projectKey);
     const projectName = project ? project.displayName : projectKey;
+    function hashBtn(id) {
+      return `<button class="hash-btn" data-id="${id}">${id.slice(0, 8)}\u2026</button>`;
+    }
     if (agentId) {
-      breadcrumb.textContent = `${projectName} / ${sessionId.slice(0, 8)}… / agent`;
+      breadcrumb.innerHTML = `<span>${projectName}</span><span> / </span>${hashBtn(sessionId)}<span> / </span>${hashBtn(agentId)}`;
     } else {
-      breadcrumb.textContent = `${projectName} / ${sessionId.slice(0, 8)}…`;
+      breadcrumb.innerHTML = `<span>${projectName}</span><span> / </span>${hashBtn(sessionId)}`;
     }
 
     vscode.postMessage({ command: 'loadConversation', projectKey, sessionId, agentId });
@@ -1139,6 +1211,7 @@
         break;
       }
       case 'Escape': {
+        closeHashDropdown();
         e.preventDefault();
         selectedSessionId = null; selectedAgentId = null; selectedProjectKey = null;
         exportBtn.style.display = 'none';

--- a/media/style.css
+++ b/media/style.css
@@ -639,8 +639,45 @@ button {
   font-family: var(--vscode-editor-font-family, monospace);
   flex: 1;
   overflow: hidden;
-  text-overflow: ellipsis;
   white-space: nowrap;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.hash-btn {
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  font-size: 12px;
+  color: var(--vscode-descriptionForeground);
+  font-family: var(--vscode-editor-font-family, monospace);
+}
+.hash-btn:hover {
+  text-decoration: underline;
+  color: var(--vscode-foreground);
+}
+
+#hash-dropdown {
+  position: fixed;
+  z-index: 1000;
+  background: var(--vscode-menu-background);
+  color: var(--vscode-menu-foreground);
+  border: 1px solid var(--vscode-menu-border);
+  border-radius: 4px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+  min-width: 180px;
+}
+
+.hash-dropdown-item {
+  padding: 5px 10px;
+  cursor: pointer;
+  font-size: 12px;
+}
+.hash-dropdown-item:hover {
+  background: var(--vscode-menu-selectionBackground);
+  color: var(--vscode-menu-selectionForeground);
 }
 
 /* ── LIVE Indicator ──────────────────────────────────────────────────────── */


### PR DESCRIPTION
Replaces the plain-text breadcrumb with structured HTML containing clickable hash buttons for session and agent IDs. Clicking a hash opens a dropdown with three options:

- Copy the raw ID
- Copy \`claude -c <id>\` (resume)
- Copy \`claude -r <id> --fork-session\` (fork)

Dropdown dismisses on outside click, Escape, or item selection. The button shows "Copied!" for 1.5s after a successful clipboard write.

---
```
(\__/)
(+'.'+)
(")_(")
```
Bunny helped with this PR and is one step closer to world domination...
