### PR TITLE
Exclude CLAUDE.md and PNG screenshots from VSIX

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -17,3 +17,5 @@ jest.config.js
 jest.config.*.js
 package-lock.json
 HOW_TO_RELEASE.md
+CLAUDE.md
+*.png


### PR DESCRIPTION
Removes development-only and README-only files from the extension package to fix a significant size regression introduced in v0.2.0.

- `CLAUDE.md` is a Claude Code development file with no relevance to extension users
- `*.png` screenshots are only needed for the marketplace README, not bundled in the VSIX

This reduces the VSIX size from ~325KB back toward the ~50KB baseline seen in v0.1.0.

---
```
(\__/)
(+'.'+)
(")_(")
```
Bunny helped with this PR and is one step closer to world domination...
