### PR TITLE
Design for thinking-steps view in conversation viewer

### DIFF
--- a/docs/superpowers/specs/2026-04-28-thinking-steps-design.md
+++ b/docs/superpowers/specs/2026-04-28-thinking-steps-design.md
@@ -1,0 +1,333 @@
+# Thinking Steps in Conversation Viewer — Design
+
+**Status:** Approved
+**Date:** 2026-04-28
+**Author:** Kyle Walker (with Claude)
+
+## Summary
+
+Surface Claude Code's `thinking` content blocks in the Agent Manager panel. The
+extension currently parses `text` and `tool_use` blocks from session JSONL files
+and ignores `thinking` blocks entirely. This spec adds `thinking` as a
+first-class `MessageBlock` type, renders non-empty thinking inline as a
+collapsed pill, adds a new `'reasoning'` session status, and includes thinking
+content in Markdown exports — all gated behind a single persisted toggle.
+
+## Background and Constraints
+
+Claude Code emits `thinking` content blocks of the form:
+
+```json
+{ "type": "thinking", "thinking": "...", "signature": "Ep..." }
+```
+
+A survey of 200 local JSONL files found 1,804 thinking blocks total; only 1 had
+non-empty `thinking` text. The remaining 1,803 had empty text and a long opaque
+`signature`. This is consistent with Anthropic's redacted-thinking behavior: the
+client receives a verifiable signature placeholder, not the raw reasoning, on
+most configurations.
+
+Two consequences shape the design:
+
+1. Rendering every thinking block by default would flood viewers with empty
+   `(redacted)` placeholders that carry no information.
+2. The *presence* of a thinking block is still meaningful — it tells us the
+   model is reasoning between tool calls — even when content is redacted, so
+   the status signal can use redacted blocks even though rendering does not.
+
+## Goals
+
+- Show non-empty thinking content inline in the conversation viewer when
+  enabled.
+- Add a distinct `'reasoning'` live status when the last assistant block is a
+  thinking block.
+- Export non-empty thinking content alongside the rest of the conversation.
+- All three behaviors are controlled by a single persisted toggle, default OFF.
+- Toggle is reachable from the top of the Agent Manager panel without a
+  settings dive.
+
+## Non-Goals
+
+- Decoding or reconstructing redacted thinking content.
+- Rendering thinking signatures or any cryptographic metadata.
+- Filtering, searching, or analyzing thinking text (future work).
+- Displaying thinking blocks anywhere outside the conversation viewer (e.g.
+  not in session list previews or summary stats).
+
+## User-Visible Behavior
+
+### Toggle
+
+A new control at the top of the Agent Manager panel, near the existing refresh
+control, labeled **Show thinking** (with a tooltip: "Show Claude's reasoning
+steps when available. Most thinking is redacted by Anthropic and won't display
+even when enabled."). State persists in `ManagerSettings.showThinking` via the
+existing `globalState.managerSettings` mechanism. Default: `false`.
+
+### Conversation viewer
+
+When `showThinking === true` and a `thinking` block has non-empty text:
+
+- Render a collapsed pill above the surrounding text, styled like the existing
+  tool-block badge: a 💭 icon, the label `Thinking`, and a short preview of
+  the first ~60 chars of the thinking text.
+- Click the pill to expand inline; expanded content is markdown-rendered using
+  the existing `marked.min.js` and styled dim/italic to distinguish it from
+  the assistant's user-facing reply.
+- When `showThinking === false` or the block's `thinking.trim() === ''`, the
+  block is not rendered at all (no badge, no placeholder).
+
+### Session status
+
+A new `SessionStatus` value: `'reasoning'`. `deriveStatus()` returns
+`'reasoning'` when the last assistant content block has type `'thinking'`,
+regardless of whether its text is empty (presence is the signal).
+
+The panel UI maps `'reasoning'` to a distinct status dot only when
+`showThinking === true`; when the toggle is off, the panel falls back to
+displaying the existing `'thinking'` status dot for `'reasoning'` sessions, so
+users who have not opted in see no behavior change.
+
+### Markdown export
+
+When `showThinking === true`, non-empty thinking blocks render in the export as:
+
+```markdown
+<details>
+<summary>💭 Thinking</summary>
+
+{thinking text, verbatim}
+
+</details>
+```
+
+When `showThinking === false`, or for redacted (empty) thinking blocks,
+nothing is emitted. Thinking sections appear positionally in the assistant's
+block stream, before any text or tool block they precede in the source JSONL.
+
+## Architecture
+
+```
+~/.claude/projects/**/*.jsonl
+   └── assistant message.content[]
+        ├── { type: "thinking", thinking, signature }   ← parsed
+        ├── { type: "text", text }                      ← parsed (today)
+        └── { type: "tool_use", ... }                   ← parsed (today)
+                       │
+                       ▼
+src/claudeReader.ts   (always parses; toggle-agnostic)
+   • extractBlocks() emits MessageBlock { type: 'thinking', content }
+   • deriveStatus() returns 'reasoning' when last assistant block
+     has type 'thinking'
+                       │
+       ┌───────────────┼────────────────┐
+       ▼               ▼                ▼
+agentManagerPanel    exporter.ts     media/main.js
+   reads               renders         renders
+   showThinking;       <details>       collapsed pill;
+   maps                blocks for      hides redacted
+   reasoning→thinking  non-empty       and the entire
+   when toggle off     thinking when   block when
+                       showThinking    showThinking
+                       === true        === false
+```
+
+The reader is a pure function of file content. All three consumers receive the
+full block stream and the current `showThinking` flag and decide what to
+render. This keeps parsing deterministic, allows the toggle to flip without
+re-reading any files, and avoids special-casing `'reasoning'` outside the
+panel UI.
+
+## Components and Changes
+
+### `src/types.ts`
+
+```ts
+export type SessionStatus =
+  | 'active' | 'thinking' | 'reasoning' | 'waiting' | 'recent' | 'idle';
+
+export interface MessageBlock {
+  type: 'text' | 'tool' | 'thinking';
+  content: string;          // for thinking: the raw thinking text (may be '')
+  toolUseId?: string;
+  description?: string;
+  input?: string;
+  output?: string;
+  isError?: boolean;
+  preview?: string;
+}
+
+export interface ManagerSettings {
+  soundEnabled: boolean;
+  soundRepeatSec: number;
+  exportTemplate: string;
+  exportLinkStyle: 'markdown' | 'wiki';
+  exportToolFormat: 'compact' | 'expanded' | 'omit';
+  showThinking: boolean;    // NEW
+}
+```
+
+`MessageBlock` retains its existing shape; thinking blocks set `type:
+'thinking'` and use `content` for the thinking text. No new fields are added —
+the cryptographic `signature` is intentionally discarded at the parser
+boundary since it has no UI use.
+
+### `src/claudeReader.ts`
+
+- `extractBlocks()` gains a branch:
+  ```ts
+  } else if (item.type === 'thinking') {
+    blocks.push({ type: 'thinking', content: item.thinking ?? '' });
+  }
+  ```
+  The raw JSONL uses `thinking` as the field name; `ContentItem` is widened to
+  include `thinking?: string`.
+- `getLastContentBlock()` continues to return the last raw content item
+  unchanged.
+- `deriveStatus()` adds a branch *before* the existing tool/text branches:
+  ```ts
+  if (lastContentBlockType === 'thinking') return 'reasoning';
+  ```
+  This applies whether the thinking text is empty or not.
+- The session/sub-agent stat counters (`assistantLines`, `userChars`,
+  `codeLines`, `toolCounts`) intentionally **do not** count thinking text;
+  these counters reflect user-visible work, and thinking is mostly redacted.
+
+### `src/agentManagerPanel.ts`
+
+- Add `showThinking: false` to `DEFAULT_SETTINGS`.
+- The settings round-trip in `_getSettings()`/`_updateSettings()` already
+  spreads over defaults, so persisted settings without `showThinking` keep
+  default OFF; no migration is needed.
+- Pass `showThinking` to the webview via the existing settings broadcast.
+- Pass `showThinking` to `exporter` calls (new parameter; see below).
+- The panel maps `'reasoning'` status → `'thinking'` for status-dot display
+  when `settings.showThinking === false`. This is a UI-side fallback and lives
+  in the panel/webview, not in `deriveStatus()`.
+
+### `src/exporter.ts`
+
+- `renderMessages(messages, format, showThinking)` gains a `showThinking`
+  parameter (or, equivalently, a single options object — chosen during
+  implementation to minimise call-site churn).
+- Inside the block loop:
+  ```ts
+  if (block.type === 'thinking') {
+    if (showThinking && block.content.trim() !== '') {
+      parts.push(`<details>\n<summary>💭 Thinking</summary>\n\n${block.content}\n\n</details>\n\n`);
+    }
+    continue;
+  }
+  ```
+- `buildRootMarkdown()` and the agent export path receive `showThinking` from
+  the panel. Tests in `exporter.test.ts` use `defaultSettings` already and add
+  `showThinking: false` to satisfy the type.
+
+### `media/main.js` and `media/style.css`
+
+- Add a top-bar `<label><input type="checkbox" id="show-thinking">Show thinking</label>` next to the existing top-bar controls. Wire it to post a settings update message and to re-render.
+- The block renderer adds a `'thinking'` branch that mirrors the tool-block
+  pattern: a clickable pill that expands to show markdown-rendered content.
+  Skip rendering entirely when `!settings.showThinking || !block.content.trim()`.
+- CSS: a new `.thinking-block` class with dim text colour, italic emphasis,
+  and a left-border accent distinct from tool blocks. The collapsed pill uses
+  a 💭 icon and shares the existing pill base styles.
+
+## Data Flow
+
+1. User opens panel → `agentManagerPanel.ts` reads `managerSettings` from
+   `globalState`, fills in defaults including `showThinking: false`.
+2. Panel sends settings + project list to webview.
+3. User toggles **Show thinking**. Webview posts `{type: 'updateSettings',
+   settings}` → panel persists → panel rebroadcasts settings.
+4. User opens a session → panel calls `readConversation()`. Returned
+   `ConversationMessage[]` always includes thinking blocks.
+5. Webview renders blocks honouring `settings.showThinking` (filter + visual
+   treatment).
+6. Status dots: panel computes session status with `deriveStatus()` (returns
+   `'reasoning'` when applicable) → webview maps `'reasoning'` → `'thinking'`
+   for display when `settings.showThinking === false`.
+7. Export: panel passes `settings.showThinking` to `exporter.ts`, which emits
+   `<details>` blocks for non-empty thinking when enabled.
+
+## Error Handling
+
+- Malformed thinking blocks (missing `thinking` field): `extractBlocks()`
+  treats `content` as `''`. Empty thinking is already filtered from
+  rendering and export, so it disappears silently.
+- Stat counters are unaffected by thinking blocks, so corrupt thinking data
+  cannot poison session aggregates.
+- Toggle persistence failures fall through to defaults via the existing
+  spread-over-defaults pattern — no new failure modes.
+- The webview must guard against running marked() on the empty string for
+  thinking-block render paths (already handled by the empty-content filter
+  above).
+
+## Testing
+
+All work follows TDD. Each cycle: failing test → minimal implementation → green.
+
+### `src/test/unit/claudeReader.test.ts`
+
+- `extractBlocks()` returns a `'thinking'` block with the raw text when given
+  `{type: 'thinking', thinking: '...'}`.
+- `extractBlocks()` returns a `'thinking'` block with empty `content` when
+  given an empty/missing `thinking` field.
+- `deriveStatus()` returns `'reasoning'` when last assistant block is
+  `'thinking'`, regardless of empty/non-empty.
+- `parseSession()` does not increment `assistantLines` or `codeLines` for
+  thinking blocks.
+- A fixture JSONL is added under `src/test/fixtures/` containing assistant
+  messages whose content arrays mix thinking, text, and tool_use blocks in
+  realistic order.
+
+### `src/test/unit/exporter.test.ts`
+
+- With `showThinking: true` and a non-empty thinking block, output contains
+  the expected `<details>…</details>` section.
+- With `showThinking: true` and an empty thinking block, output contains no
+  `<details>` section for that block.
+- With `showThinking: false`, output contains no `<details>` section even
+  when a non-empty thinking block exists.
+- Existing exporter tests are updated to pass `showThinking: false` (matches
+  the default) so behaviour is unchanged for current callers.
+
+### Webview / integration
+
+- A Mocha integration test (`src/test/integration/...`) covers the toggle
+  round-trip: panel-open → toggle on → settings persisted → panel-reopen →
+  toggle still on. The webview rendering itself is exercised manually (per
+  `docs/testing.md`), not via headless integration.
+
+## Migration / Compatibility
+
+- Existing persisted `managerSettings` without `showThinking` get `false`
+  on load via the spread-over-defaults pattern. No migration code required.
+- `MessageBlock` consumers must handle the new `'thinking'` type. TypeScript's
+  exhaustiveness on the discriminated union catches missing branches at
+  compile time.
+- `SessionStatus` consumers must handle `'reasoning'`. The webview maps it
+  for display; status-aware tests are updated accordingly.
+
+## Out of Scope (future work)
+
+- Per-project or per-session toggle granularity (ship as global only).
+- Thinking-block search or aggregation UI.
+- Rendering of thinking signatures or hashes.
+- Capturing thinking from upstream-redacted sessions.
+
+## Acceptance Criteria
+
+1. With `showThinking: false` (default), the conversation viewer, status
+   dots, and exported Markdown are byte-for-byte equivalent to today's
+   output for any session that contains thinking blocks.
+2. With `showThinking: true`, non-empty thinking blocks render as collapsed
+   pills that expand on click and show markdown-rendered content.
+3. Empty thinking blocks never render in the viewer or appear in exports
+   regardless of toggle state.
+4. A session whose last assistant block is `thinking` shows the `'reasoning'`
+   status dot when `showThinking: true`, and the existing `'thinking'` dot
+   when `showThinking: false`.
+5. The toggle persists across panel reopens via `globalState.managerSettings`.
+6. All new behaviour is covered by unit tests in `claudeReader.test.ts` and
+   `exporter.test.ts`; existing tests still pass.

--- a/media/main.js
+++ b/media/main.js
@@ -38,7 +38,7 @@
   let filterText = '';
   let activeFilter = 'all';
   let pinnedKeys = new Set();
-  let settings = { soundEnabled: false, soundRepeatSec: 0, exportTemplate: '~/Documents/claude-exports/{slug}.md', exportLinkStyle: 'markdown', exportToolFormat: 'compact' };
+  let settings = { soundEnabled: false, soundRepeatSec: 0, exportTemplate: '~/Documents/claude-exports/{slug}.md', exportLinkStyle: 'markdown', exportToolFormat: 'compact', showThinking: false };
   let previousWaitingIds = new Set();
   let soundRepeatTimer = null;
   let audioCtx = null;
@@ -63,6 +63,8 @@
   let focusedIndex = -1;
   let layoutMode = 'wide';
   let renderedMessageCount = 0;
+  /** Most recent conversation messages, kept so the view can re-render when settings change. */
+  let currentMessages = [];
 
   // Tailing state
   /** @type {ReturnType<typeof setTimeout> | null} */
@@ -473,9 +475,24 @@
     });
   });
 
+  const showThinkingCb = document.getElementById('show-thinking');
+  if (showThinkingCb) {
+    showThinkingCb.addEventListener('change', () => {
+      settings.showThinking = showThinkingCb.checked;
+      pushSettings();
+      // Re-render sidebar (status dots may change) and conversation
+      renderSidebar(filtered());
+      if (selectedSessionId) {
+        renderedMessageCount = 0;
+        renderConversation(currentMessages);
+      }
+    });
+  }
+
   function syncSettingsUI() {
     soundEnabledCb.checked = settings.soundEnabled;
     soundRepeatSel.value = String(settings.soundRepeatSec);
+    if (showThinkingCb) showThinkingCb.checked = !!settings.showThinking;
     if (exportTemplateInput) {
       exportTemplateInput.value = settings.exportTemplate || '~/Documents/claude-exports/{slug}.md';
       resizeTemplateInput();
@@ -633,6 +650,7 @@
     if (!ts) return 'idle';
     const mins = (Date.now() - new Date(ts).getTime()) / 60000;
     if (mins < 5) {
+      if (precomputedStatus === 'reasoning') return settings.showThinking ? 'reasoning' : 'thinking';
       if (precomputedStatus === 'thinking') return 'thinking';
       if (precomputedStatus === 'waiting') return 'waiting';
       return 'active';
@@ -1141,6 +1159,7 @@
   // ── Conversation Render ────────────────────────────────────────────────────
   function renderConversation(messages, sessionId, agentId) {
     const container = document.getElementById('conversation-container');
+    currentMessages = messages || [];
 
     if (!messages || messages.length === 0) {
       container.innerHTML = '<div class="conv-empty"><p>No messages in this conversation.</p></div>';
@@ -1168,6 +1187,13 @@
       });
     });
 
+    // Thinking pill click-to-expand
+    container.querySelectorAll('.thinking-block-header').forEach((header) => {
+      header.addEventListener('click', () => {
+        header.closest('.thinking-block').classList.toggle('expanded');
+      });
+    });
+
     container.scrollTop = container.scrollHeight;
     renderedMessageCount = messages.length;
   }
@@ -1191,6 +1217,11 @@
           i++;
         }
         blocksHtml += `<div class="tool-badges">${toolBadgesHtml}</div>`;
+      } else if (block.type === 'thinking') {
+        if (settings.showThinking && block.content && block.content.trim()) {
+          blocksHtml += renderThinkingBlock(block);
+        }
+        i++;
       } else {
         blocksHtml += `<div class="msg-text">${formatText(block.content)}</div>`;
         i++;
@@ -1204,6 +1235,21 @@
     <span class="msg-time">${timeStr}</span>
   </div>
   <div class="msg-body">${blocksHtml}</div>
+</div>`;
+  }
+
+  function renderThinkingBlock(block) {
+    const text = block.content || '';
+    const previewSrc = text.replaceAll(/\s+/g, ' ').trim();
+    const preview = previewSrc.length > 60 ? previewSrc.slice(0, 60) + '…' : previewSrc;
+    return `
+<div class="thinking-block">
+  <div class="thinking-block-header">
+    <span class="thinking-icon">💭</span>
+    <span class="thinking-label">Thinking</span>
+    <span class="thinking-preview">${esc(preview)}</span>
+  </div>
+  <div class="thinking-detail">${formatText(text)}</div>
 </div>`;
   }
 
@@ -1342,6 +1388,7 @@
 
     const newMessages = messages.slice(renderedMessageCount);
     renderedMessageCount = newCount;
+    currentMessages = messages;
 
     // Insert NEW divider if user is scrolled up
     if (!isUserAtBottom && !container.querySelector('.new-msg-divider')) {
@@ -1363,6 +1410,11 @@
         msgEl.querySelectorAll('.tool-badge-header').forEach((header) => {
           header.addEventListener('click', () => {
             header.closest('.tool-badge').classList.toggle('expanded');
+          });
+        });
+        msgEl.querySelectorAll('.thinking-block-header').forEach((header) => {
+          header.addEventListener('click', () => {
+            header.closest('.thinking-block').classList.toggle('expanded');
           });
         });
         setTimeout(() => { msgEl.classList.add('msg-new-faded'); }, 2000);

--- a/media/style.css
+++ b/media/style.css
@@ -672,6 +672,12 @@ button {
   animation: pulse-thinking 1.4s ease-in-out infinite;
 }
 
+.status-dot.reasoning {
+  background: #c084fc;
+  box-shadow: 0 0 0 2px rgba(192, 132, 252, 0.2);
+  animation: pulse-thinking 1.4s ease-in-out infinite;
+}
+
 @keyframes pulse-thinking {
   0%, 100% { opacity: 1; transform: scale(1); }
   50% { opacity: 0.5; transform: scale(0.75); }
@@ -977,6 +983,84 @@ button {
   line-height: 1.6;
   color: var(--vscode-foreground);
   padding-left: 2px;
+}
+
+/* ── Thinking Block ────────────────────────────────────────────────────────── */
+.thinking-block {
+  display: block;
+  margin: 4px 0;
+  border-left: 2px solid #c084fc;
+  border-radius: 4px;
+  background: rgba(192, 132, 252, 0.06);
+  cursor: pointer;
+  transition: background 0.15s;
+  font-style: italic;
+}
+
+.thinking-block:hover {
+  background: rgba(192, 132, 252, 0.12);
+}
+
+.thinking-block-header {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  padding: 5px 10px;
+  user-select: none;
+}
+
+.thinking-icon {
+  font-size: 12px;
+  flex-shrink: 0;
+}
+
+.thinking-label {
+  font-size: 12px;
+  font-weight: 500;
+  color: #c084fc;
+  font-style: normal;
+}
+
+.thinking-preview {
+  font-size: 11px;
+  color: var(--vscode-descriptionForeground);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.thinking-block.expanded .thinking-preview {
+  display: none;
+}
+
+.thinking-detail {
+  display: none;
+  padding: 4px 14px 10px 14px;
+  font-size: 12px;
+  color: var(--vscode-descriptionForeground);
+  line-height: 1.5;
+}
+
+.thinking-block.expanded .thinking-detail {
+  display: block;
+}
+
+/* ── Sidebar header: Show thinking toggle ─────────────────────────────────── */
+.show-thinking-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 11px;
+  color: var(--vscode-descriptionForeground);
+  cursor: pointer;
+  user-select: none;
+}
+
+.show-thinking-toggle input[type="checkbox"] {
+  margin: 0;
+  cursor: pointer;
 }
 
 /* ── Tool Badge (collapsed) ───────────────────────────────────────────────── */

--- a/src/agentManagerPanel.ts
+++ b/src/agentManagerPanel.ts
@@ -14,6 +14,7 @@ const DEFAULT_SETTINGS: ManagerSettings = {
   exportTemplate: '~/Documents/claude-exports/{slug}.md',
   exportLinkStyle: 'markdown',
   exportToolFormat: 'compact',
+  showThinking: false,
 };
 
 export class AgentManagerPanel {
@@ -476,6 +477,10 @@ export class AgentManagerPanel {
       <div class="sidebar-header">
         <span class="sidebar-title" title="Keyboard: j/k to navigate, ? for help">Agent Manager</span>
         <div class="sidebar-actions">
+          <label class="show-thinking-toggle" title="Show Claude's reasoning steps when available. Most thinking is redacted by Anthropic and won't display even when enabled.">
+            <input type="checkbox" id="show-thinking" />
+            <span>Thinking</span>
+          </label>
           <span class="last-updated" id="last-updated"></span>
           <button class="icon-btn" id="refresh-btn" title="Refresh">
             <svg viewBox="0 0 16 16" fill="currentColor"><path d="M13.5 2.5a.5.5 0 0 1 .5.5v3a.5.5 0 0 1-.5.5h-3a.5.5 0 0 1 0-1h1.79A5.5 5.5 0 1 0 13.5 8a.5.5 0 0 1 1 0 6.5 6.5 0 1 1-2.035-4.715L13.5 2.5z"/></svg>

--- a/src/claudeReader.ts
+++ b/src/claudeReader.ts
@@ -9,6 +9,7 @@ const MAX_SESSION_AGE_DAYS = 30;
 interface ContentItem {
   type: string;
   text?: string;
+  thinking?: string;
   name?: string;
   id?: string;
   input?: Record<string, unknown>;
@@ -79,6 +80,7 @@ function deriveStatus(
   if (!lastMessageRole) return 'idle';
   if (lastMessageRole === 'user') return 'active';
   // lastMessageRole === 'assistant'
+  if (lastContentBlockType === 'thinking') return 'reasoning';
   if (lastContentBlockType === 'tool_use') return 'thinking';
   // text block ending with a question mark → genuinely waiting for user input
   if (lastContentBlockType === 'text' && lastContentBlockText && QUESTION_MARK_RE.test(lastContentBlockText)) {
@@ -588,6 +590,8 @@ function extractBlocks(
       blocks.push({ type: 'text', content: item.text });
     } else if (item.type === 'tool_use' && item.name) {
       blocks.push(buildToolBlock(item, toolResults));
+    } else if (item.type === 'thinking') {
+      blocks.push({ type: 'thinking', content: item.thinking ?? '' });
     }
   }
   return blocks;

--- a/src/exporter.ts
+++ b/src/exporter.ts
@@ -185,7 +185,11 @@ export function renderToolBlock(block: { content: string; preview?: string; inpu
   return `> **${name}**\n${inputSection}${outputSection}\n`;
 }
 
-function renderMessages(messages: ConversationMessage[], format: ManagerSettings['exportToolFormat']): string {
+function renderMessages(
+  messages: ConversationMessage[],
+  format: ManagerSettings['exportToolFormat'],
+  showThinking: boolean,
+): string {
   const parts: string[] = [];
 
   for (const msg of messages) {
@@ -196,6 +200,10 @@ function renderMessages(messages: ConversationMessage[], format: ManagerSettings
     for (const block of msg.blocks) {
       if (block.type === 'text') {
         parts.push(block.content.trim() + '\n\n');
+      } else if (block.type === 'thinking') {
+        if (showThinking && block.content.trim() !== '') {
+          parts.push(`<details>\n<summary>💭 Thinking</summary>\n\n${block.content}\n\n</details>\n\n`);
+        }
       } else {
         const rendered = renderToolBlock(block, format);
         if (rendered) parts.push(rendered);
@@ -213,6 +221,7 @@ function buildRootMarkdown(
   agentLinks: Array<{ label: string; filename: string }>,
   format: ManagerSettings['exportToolFormat'],
   linkStyle: ManagerSettings['exportLinkStyle'],
+  showThinking: boolean,
 ): string {
   const titlePrompt = session.firstPrompt
     ? truncate(session.firstPrompt, 80)
@@ -241,7 +250,7 @@ function buildRootMarkdown(
   }
 
   lines.push('## Conversation\n');
-  lines.push(renderMessages(messages, format));
+  lines.push(renderMessages(messages, format, showThinking));
 
   return lines.join('\n');
 }
@@ -253,6 +262,7 @@ function buildAgentMarkdown(
   messages: ConversationMessage[],
   format: ManagerSettings['exportToolFormat'],
   linkStyle: ManagerSettings['exportLinkStyle'],
+  showThinking: boolean,
 ): string {
   const title = agent.slug ?? agent.agentId.slice(0, 8);
   const rootFilenameNoExt = rootFilename.replace(/\.md$/, '');
@@ -264,7 +274,7 @@ function buildAgentMarkdown(
   lines.push(`${backLink}\n`);
   lines.push(`# Agent: ${title}\n`);
   lines.push('## Conversation\n');
-  lines.push(renderMessages(messages, format));
+  lines.push(renderMessages(messages, format, showThinking));
 
   return lines.join('\n');
 }
@@ -277,6 +287,7 @@ export function exportConversation(
   const { projectKey, sessionId, displayName, session, readConversation } = params;
   const format = settings.exportToolFormat;
   const linkStyle = settings.exportLinkStyle ?? 'markdown';
+  const showThinking = settings.showThinking ?? false;
 
   const rootDir = path.dirname(rootPath);
   const rootBasename = path.basename(rootPath, '.md');
@@ -306,14 +317,14 @@ export function exportConversation(
     const agentFilename = `${rootBasename}-agent-${label}.md`;
     agentLinks.push({ label, filename: agentFilename });
 
-    const agentContent = buildAgentMarkdown(agent, label, path.basename(rootPath), agentMessages, format, linkStyle);
+    const agentContent = buildAgentMarkdown(agent, label, path.basename(rootPath), agentMessages, format, linkStyle, showThinking);
     const agentPath = path.join(rootDir, agentFilename);
     fs.writeFileSync(agentPath, agentContent, 'utf-8');
     agentPaths.push(agentPath);
   }
 
   // Write root file — content-aware path selection avoids duplicates
-  const rootContent = buildRootMarkdown(session, displayName, rootMessages, agentLinks, format, linkStyle);
+  const rootContent = buildRootMarkdown(session, displayName, rootMessages, agentLinks, format, linkStyle, showThinking);
   const actualRootPath = resolveRootPath(rootPath, rootContent);
   fs.writeFileSync(actualRootPath, rootContent, 'utf-8');
 

--- a/src/test/unit/claudeReader.test.ts
+++ b/src/test/unit/claudeReader.test.ts
@@ -164,6 +164,39 @@ describe('readConversation', () => {
     expect(result).toHaveLength(2);
   });
 
+  test('parses thinking block with non-empty text', () => {
+    jest.mocked(fs.readFileSync).mockReturnValue(
+      JSON.stringify({
+        type: 'assistant',
+        message: { content: [{ type: 'thinking', thinking: 'reasoning here', signature: 'EpAB...' }] },
+      })
+    );
+    const result = readConversation('proj', 'sess');
+    expect(result[0].blocks).toEqual([{ type: 'thinking', content: 'reasoning here' }]);
+  });
+
+  test('parses thinking block with empty text as empty content', () => {
+    jest.mocked(fs.readFileSync).mockReturnValue(
+      JSON.stringify({
+        type: 'assistant',
+        message: { content: [{ type: 'thinking', thinking: '', signature: 'EpAB...' }] },
+      })
+    );
+    const result = readConversation('proj', 'sess');
+    expect(result[0].blocks).toEqual([{ type: 'thinking', content: '' }]);
+  });
+
+  test('parses thinking block with missing thinking field as empty content', () => {
+    jest.mocked(fs.readFileSync).mockReturnValue(
+      JSON.stringify({
+        type: 'assistant',
+        message: { content: [{ type: 'thinking', signature: 'EpAB...' }] },
+      })
+    );
+    const result = readConversation('proj', 'sess');
+    expect(result[0].blocks).toEqual([{ type: 'thinking', content: '' }]);
+  });
+
   test('uses agentId path when provided', () => {
     jest.mocked(fs.readFileSync).mockReturnValue('');
     readConversation('proj', 'sess', 'agent123');
@@ -355,6 +388,20 @@ describe('userChars, assistantLines, codeLines (via readClaudeProjects)', () => 
     expect(projects[0].sessions[0].codeLines).toBe(5); // Write: 3, Edit: 2, Bash: ignored
   });
 
+  test('thinking blocks do not contribute to assistantLines or codeLines', () => {
+    const lines = [
+      JSON.stringify({ type: 'user', timestamp: recentTs(), cwd: '/work', message: { content: 'hello world' } }),
+      JSON.stringify({
+        type: 'assistant', timestamp: recentTs(),
+        message: { content: [{ type: 'thinking', thinking: 'a\nb\nc\nd' }] },
+      }),
+    ].join('\n');
+    setupSingleProject(lines);
+    const projects = readClaudeProjects();
+    expect(projects[0].sessions[0].assistantLines).toBe(0);
+    expect(projects[0].sessions[0].codeLines).toBe(0);
+  });
+
   test('assistantLines and codeLines default to 0 with no assistant messages', () => {
     const lines = [
       JSON.stringify({ type: 'user', timestamp: recentTs(), cwd: '/work', message: { content: 'hello world' } }),
@@ -426,6 +473,32 @@ describe('deriveStatus (via readClaudeProjects)', () => {
     setupSingleProject(lines);
     const projects = readClaudeProjects();
     expect(projects[0].sessions[0].status).toBe('waiting');
+  });
+
+  test('reasoning when last assistant message ends with a non-empty thinking block', () => {
+    const lines = [
+      JSON.stringify({ type: 'user', timestamp: recentTs(), cwd: '/work', message: { content: 'hello world' } }),
+      JSON.stringify({
+        type: 'assistant', timestamp: recentTs(),
+        message: { content: [{ type: 'thinking', thinking: 'pondering' }] },
+      }),
+    ].join('\n');
+    setupSingleProject(lines);
+    const projects = readClaudeProjects();
+    expect(projects[0].sessions[0].status).toBe('reasoning');
+  });
+
+  test('reasoning when last assistant message ends with an empty (redacted) thinking block', () => {
+    const lines = [
+      JSON.stringify({ type: 'user', timestamp: recentTs(), cwd: '/work', message: { content: 'hello world' } }),
+      JSON.stringify({
+        type: 'assistant', timestamp: recentTs(),
+        message: { content: [{ type: 'thinking', thinking: '', signature: 'Ep...' }] },
+      }),
+    ].join('\n');
+    setupSingleProject(lines);
+    const projects = readClaudeProjects();
+    expect(projects[0].sessions[0].status).toBe('reasoning');
   });
 
   test('waiting when last assistant message ends with Arabic question mark \u061f', () => {

--- a/src/test/unit/exporter.test.ts
+++ b/src/test/unit/exporter.test.ts
@@ -15,6 +15,7 @@ const defaultSettings: ManagerSettings = {
   exportTemplate: '~/Documents/claude-exports/{slug}.md',
   exportLinkStyle: 'markdown',
   exportToolFormat: 'compact',
+  showThinking: false,
 };
 
 const baseSession: ClaudeSession = {
@@ -191,6 +192,61 @@ describe('exportConversation', () => {
     const agentContent = String(jest.mocked(fs.writeFileSync).mock.calls[0][1]);
     expect(agentContent).toContain('← [Back to session](./session.md)');
     expect(result.agentPaths).toEqual(['/tmp/session-agent-explore.md']);
+  });
+
+  test('renders non-empty thinking block as <details> when showThinking is true', () => {
+    const params: ExportParams = {
+      ...baseParams,
+      readConversation: () => [
+        {
+          role: 'assistant',
+          blocks: [{ type: 'thinking', content: 'I should consider edge cases.' }],
+          timestamp: '2024-01-01T00:00:01Z',
+        },
+      ],
+    };
+    const settings = { ...defaultSettings, showThinking: true };
+    exportConversation(params, settings, '/tmp/session.md');
+    const rootContent = String(jest.mocked(fs.writeFileSync).mock.calls[0][1]);
+    expect(rootContent).toContain('<details>');
+    expect(rootContent).toContain('<summary>💭 Thinking</summary>');
+    expect(rootContent).toContain('I should consider edge cases.');
+    expect(rootContent).toContain('</details>');
+  });
+
+  test('omits empty thinking block even when showThinking is true', () => {
+    const params: ExportParams = {
+      ...baseParams,
+      readConversation: () => [
+        {
+          role: 'assistant',
+          blocks: [{ type: 'thinking', content: '' }],
+          timestamp: '2024-01-01T00:00:01Z',
+        },
+      ],
+    };
+    const settings = { ...defaultSettings, showThinking: true };
+    exportConversation(params, settings, '/tmp/session.md');
+    const rootContent = String(jest.mocked(fs.writeFileSync).mock.calls[0][1]);
+    expect(rootContent).not.toContain('<details>');
+    expect(rootContent).not.toContain('💭 Thinking');
+  });
+
+  test('omits thinking block when showThinking is false', () => {
+    const params: ExportParams = {
+      ...baseParams,
+      readConversation: () => [
+        {
+          role: 'assistant',
+          blocks: [{ type: 'thinking', content: 'Reasoning text.' }],
+          timestamp: '2024-01-01T00:00:01Z',
+        },
+      ],
+    };
+    exportConversation(params, defaultSettings, '/tmp/session.md');
+    const rootContent = String(jest.mocked(fs.writeFileSync).mock.calls[0][1]);
+    expect(rootContent).not.toContain('<details>');
+    expect(rootContent).not.toContain('Reasoning text.');
   });
 
   test('root file links to agent sub-file', () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-export type SessionStatus = 'active' | 'thinking' | 'waiting' | 'recent' | 'idle';
+export type SessionStatus = 'active' | 'thinking' | 'reasoning' | 'waiting' | 'recent' | 'idle';
 
 export interface SubAgent {
   agentId: string;
@@ -42,7 +42,7 @@ export interface ClaudeProject {
 }
 
 export interface MessageBlock {
-  type: 'text' | 'tool';
+  type: 'text' | 'tool' | 'thinking';
   content: string;
   /** Tool-specific fields (present when type === 'tool') */
   toolUseId?: string;
@@ -66,6 +66,7 @@ export interface ManagerSettings {
   exportTemplate: string;
   exportLinkStyle: 'markdown' | 'wiki';
   exportToolFormat: 'compact' | 'expanded' | 'omit';
+  showThinking: boolean;
 }
 
 export interface HookCheck {


### PR DESCRIPTION
Attempt to add thinking blocks but these are redacted currently, creating this PR to be able to quickly return to this code if ever needed.


Here's the structure decoded as protobuf wire format. The 540-byte signature is a top-level message with two fields:

```
  top-level message
  ├─ field 2: nested message (535 bytes) ── the signed envelope
  │   ├─ field 1: header message (91 bytes)
  │   │   ├─ field 1: varint = 12              ← version/format tag
  │   │   ├─ field 3: varint = 2               ← maybe block kind
  │   │   ├─ field 5: bytes(64)                ← random nonce / salt
  │   │   ├─ field 6: string(17) = 'claude-sonnet-4-6'   ← model id
  │   │   └─ field 7: varint = 0
  │   ├─ field 2: bytes(12)                    ← opaque (counter or IV?)
  │   ├─ field 3: bytes(12)                    ← opaque
  │   ├─ field 4: bytes(48)                    ← likely a hash/digest
  │   └─ field 5: bytes(361)                   ← ciphertext / MAC payload
  └─ field 3: varint = 1                       ← outer version
```
The only human-readable field is field 6 — the literal string claude-sonnet-4-6, which tells the server which model produced the thinking, so it can pick the right key to verify the signature on a follow-up turn. Everything else (the 64-byte random block, the 48-byte digest, the 361-byte payload) is opaque cryptographic material — that's why the spec discards signature at the parser boundary: there's nothing for the UI to render usefully.
